### PR TITLE
ci: canary — migrate verify-rules now that Bazel is on smithy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify-rules:
     name: Verify rules load
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v4
       - uses: bazelbuild/setup-bazelisk@v3


### PR DESCRIPTION
## Summary

Smithy main commit `c5d4794` (feat(toolchains): add Bazel via
bazelisk + buildifier + JDK 21) made bazel/bazelisk/buildifier
available on the self-hosted fleet. This is the **single-job
canary** validating that change before we batch-migrate the
remaining ~30 Bazel-using jobs across pulseengine repos.

## What's migrated

Only `verify-rules` — two `bazel query` calls (`//lean/...` and
`//aeneas/...`). No compile, no Lean toolchain download, completes
in seconds. If this passes, the host setup is correct end-to-end.

## What stays on hosted

The `build` matrix job (`ubuntu-latest` + `macos-latest`). The
macOS half can't migrate; splitting the matrix is a separate PR
once this canary proves out.

## Why this validates the whole rollout

`bazel query` exercises the full bazelisk → bazel → JDK chain
without compile cost:

1. bazelisk reads `.bazelversion` (or its default), downloads the
   right Bazel into `~/.cache/bazelisk/`
2. Bazel starts its server, parses MODULE.bazel + BUILD files
3. The query evaluator walks the rule graph

Anything wrong with the host setup (missing JDK, broken bazelisk,
PATH issue, permissions) shows up here in seconds.

## Test plan

- [ ] CI run completes green on the smithy `light` runner
- [ ] No EACCES events in `journalctl -u smithy-trace-eacces.service`
- [ ] bazelisk's first-time Bazel download succeeds (~5-10 sec)
- [ ] `~/.cache/bazel` and `~/.cache/bazelisk` populate under the runner home
- [ ] Subsequent runs reuse the cache and complete faster

## After this lands

Spawn batch agents for: `rules_wasm_component`, `rules_rocq_rust`,
`rules_lean` (the build matrix's Linux side), `rules_moonbit`,
`wasm-component-examples`, `moonbit_checksum_updater`, `loom`. Each
gets its own PR migrating the Bazel jobs we previously had to leave
on `ubuntu-latest`.

## Rollback

Revert this commit; verify-rules flips back to `ubuntu-latest`.