### PR TITLE
Aeneas Level 2: compile + verify translated Rust (advances #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,3 +233,9 @@ jobs:
         working-directory: tests/charon_llbc
         run: bazel build @aeneas_lean_lib//:Aeneas
         timeout-minutes: 60
+      # Level 2: compile the aeneas-translated Lean against @aeneas_lean_lib —
+      # the translate -> compile bridge (kernel-checks the Rust model elaborates).
+      - name: Build hello_compiled (translate -> Lean -> compile)
+        working-directory: tests/charon_llbc
+        run: bazel build //:hello_compiled
+        timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,3 +244,8 @@ jobs:
         working-directory: tests/charon_llbc
         run: bazel build //:hello_compiled
         timeout-minutes: 30
+      # Verify: kernel-check the proofs about the translated Rust (zero sorry/axiom).
+      - name: Test hello_verified (Rust properties proved in Lean)
+        working-directory: tests/charon_llbc
+        run: bazel test //:hello_verified --test_output=errors
+        timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,11 @@ jobs:
         working-directory: tests/charon_llbc
         run: bazel build //:hello_lean_check
         timeout-minutes: 20
+      - name: Show the generated Lean (what Aeneas produced)
+        working-directory: tests/charon_llbc
+        run: |
+          echo "===== generated hello_lean.lean ====="
+          cat bazel-bin/hello_lean.lean
 
   build-aeneas-lean-lib:
     name: Aeneas Lean lib build (#7 shallow-fetch)

--- a/aeneas/private/aeneas.bzl
+++ b/aeneas/private/aeneas.bzl
@@ -13,7 +13,14 @@ AeneasInfo = provider(
 def _aeneas_translate_impl(ctx):
     toolchain = ctx.toolchains["//aeneas:toolchain_type"].aeneas_toolchain_info
 
+    # Aeneas writes its output into a -dest DIRECTORY; in the default (non-split)
+    # mode that is a single <Module>.lean. We declare both the dir (what aeneas
+    # writes) and a discrete <name>.lean (copied out of it) so a lean_library
+    # can consume the translation directly — discrete File inputs, no
+    # TreeArtifact. (Do NOT pass -split-files: that produces many files and
+    # breaks the single-file contract this rule provides.)
     out_dir = ctx.actions.declare_directory(ctx.label.name + ".lean_out")
+    out_file = ctx.actions.declare_file(ctx.label.name + ".lean")
 
     lines = [
         "#!/bin/bash",
@@ -31,22 +38,34 @@ def _aeneas_translate_impl(ctx):
         cmd += ' "{src}"'.format(src = llbc.path)
         lines.append(cmd)
 
+    # Copy the single generated module to the discrete output. Fail loudly if
+    # aeneas produced anything other than exactly one .lean (e.g. -split-files).
+    lines.append('produced=$(find "{out}" -name "*.lean")'.format(out = out_dir.path))
+    lines.append('n=$(printf "%s\\n" "$produced" | grep -c . || true)')
+    lines.append('if [ "$n" -ne 1 ]; then')
+    lines.append('    echo "aeneas_translate expects a single .lean module (non-split); got $n:" >&2')
+    lines.append('    printf "  %s\\n" $produced >&2')
+    lines.append('    exit 1')
+    lines.append('fi')
+    lines.append('cp $produced "{f}"'.format(f = out_file.path))
+
     script = ctx.actions.declare_file(ctx.label.name + "_translate.sh")
     ctx.actions.write(script, "\n".join(lines), is_executable = True)
 
     ctx.actions.run(
         executable = script,
         inputs = depset(ctx.files.srcs + toolchain.all_files),
-        outputs = [out_dir],
+        outputs = [out_dir, out_file],
         mnemonic = "AeneasTranslate",
         progress_message = "Translating LLBC to Lean via Aeneas %s" % ctx.label,
         execution_requirements = {"no-sandbox": "1"},
     )
 
     return [
-        DefaultInfo(files = depset([out_dir])),
+        # The discrete .lean is the default output so it feeds lean_library.
+        DefaultInfo(files = depset([out_file])),
         AeneasInfo(
-            lean_srcs = [out_dir],
+            lean_srcs = [out_file],
             llbc_file = ctx.files.srcs[0] if ctx.files.srcs else None,
         ),
     ]

--- a/aeneas/private/repo.bzl
+++ b/aeneas/private/repo.bzl
@@ -245,6 +245,16 @@ def _aeneas_lean_lib_impl(rctx):
                 fi
             done
         done
+        # Mathlib is a LOCAL-PATH dep (the #7 shallow-fetch redirect), so its
+        # oleans build under mathlib4_src/.lake/build — NOT .lake/packages — and
+        # would otherwise be missed, breaking `import Mathlib` (which Aeneas
+        # transitively needs). Same handling as @mathlib's own consolidation.
+        for lib_dir in mathlib4_src/.lake/build/lib/lean mathlib4_src/.lake/build/lib; do
+            if [ -d "$lib_dir" ] && ls "$lib_dir"/ >/dev/null 2>&1; then
+                cp -R "$lib_dir"/. lib/
+                break
+            fi
+        done
         # The Aeneas library itself.
         for lib_dir in backends/lean/.lake/build/lib/lean backends/lean/.lake/build/lib; do
             if [ -d "$lib_dir" ] && ls "$lib_dir"/ >/dev/null 2>&1; then

--- a/aeneas/private/repo.bzl
+++ b/aeneas/private/repo.bzl
@@ -232,17 +232,26 @@ def _aeneas_lean_lib_impl(rctx):
         fail("mkdir lib failed:\n" + mk.stderr)
     consolidate = rctx.execute(["sh", "-c", """
         set -e
+        # Lake v4 stores oleans under .lake/build/lib/lean/<Module>/...; prefer
+        # that level so modules land FLAT in lib/ (lib/Aeneas.olean), which is
+        # what `import Aeneas` resolves against the path_marker dir. Copying the
+        # outer .../lib/. instead would nest them at lib/lean/Aeneas.olean and
+        # break resolution. `break` after the first match picks the right level.
         for pkg_dir in backends/lean/.lake/packages/*/; do
-            for lib_dir in "${pkg_dir}.lake/build/lib" "${pkg_dir}build/lib"; do
+            for lib_dir in "${pkg_dir}.lake/build/lib/lean" "${pkg_dir}.lake/build/lib" "${pkg_dir}build/lib/lean" "${pkg_dir}build/lib"; do
                 if [ -d "$lib_dir" ] && ls "$lib_dir"/ >/dev/null 2>&1; then
                     cp -R "$lib_dir"/. lib/
+                    break
                 fi
             done
         done
-        # Also copy the Aeneas library itself
-        if [ -d "backends/lean/.lake/build/lib" ]; then
-            cp -R backends/lean/.lake/build/lib/. lib/
-        fi
+        # The Aeneas library itself.
+        for lib_dir in backends/lean/.lake/build/lib/lean backends/lean/.lake/build/lib; do
+            if [ -d "$lib_dir" ] && ls "$lib_dir"/ >/dev/null 2>&1; then
+                cp -R "$lib_dir"/. lib/
+                break
+            fi
+        done
     """])
     if consolidate.return_code != 0:
         fail("Aeneas olean consolidation copy failed:\n" + consolidate.stdout + "\n" + consolidate.stderr)

--- a/lean/extensions.bzl
+++ b/lean/extensions.bzl
@@ -50,21 +50,24 @@ _LeanMathlibTag = tag_class(attrs = {
     ),
 })
 
-# Mathlib release tags follow the "v{lean_version}" convention.
+# Mathlib release tags track the Lean version EXACTLY, including pre-release
+# suffixes: Lean 4.28.0-rc1 pairs with Mathlib v4.28.0-rc1 (rc-for-rc), and
+# stable Lean 4.29.1 with Mathlib v4.29.1. So we strip only the leading "v" and
+# compare the rest verbatim — NOT dropping "-rcN", which would falsely flag an
+# RC toolchain (4.28.0-rc1) against its matching RC mathlib (v4.28.0-rc1).
 def _required_lean_from_rev(rev):
     """Derive the Lean version a Mathlib rev requires.
 
     Returns (lean_version | None, is_sha):
       - "v4.29.1"      -> ("4.29.1", False)
-      - "v4.29.1-rc1"  -> ("4.29.1", False)   # pre-release suffix dropped
-      - 40-char hex    -> (None, True)        # bare SHA: version not inferable
+      - "v4.28.0-rc1"  -> ("4.28.0-rc1", False)   # rc preserved (rc-for-rc)
+      - 40-char hex    -> (None, True)            # bare SHA: version not inferable
     """
     lowered = rev.lower()
     is_sha = len(rev) == 40 and all([c in "0123456789abcdef" for c in lowered.elems()])
     if is_sha:
         return None, True
-    base = rev[1:] if rev.startswith("v") else rev
-    return base.split("-")[0], False
+    return (rev[1:] if rev.startswith("v") else rev), False
 
 def _lean_impl(module_ctx):
     # ── Toolchain ────────────────────────────────────────────────────────

--- a/tests/charon_llbc/BUILD.bazel
+++ b/tests/charon_llbc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_lean//aeneas:defs.bzl", "aeneas_translate", "charon_llbc")
+load("@rules_lean//lean:defs.bzl", "lean_library")
 
 # Translate the tiny Rust crate to LLBC via Charon.
 charon_llbc(
@@ -29,29 +30,36 @@ echo "OK $$SIZE" > $@
     testonly = True,
 )
 
-# Level-1 end-to-end: translate the LLBC to Lean 4 via the Aeneas binary.
-# Exercises aeneas_translate (LLBC -> .lean) WITHOUT compiling the result, so it
-# does not trigger the heavy @aeneas_lean_lib build.
+# Level 1: translate the LLBC to a single Lean 4 module via the Aeneas binary.
 aeneas_translate(
     name = "hello_lean",
     srcs = [":hello_llbc"],
 )
 
-# Build-time assertion: Aeneas emitted at least one .lean file.
+# Build-time assertion: aeneas emitted a non-empty .lean module.
 genrule(
     name = "hello_lean_check",
     srcs = [":hello_lean"],
     outs = ["hello_lean_check.stamp"],
     cmd = """
 set -euo pipefail
-OUT_DIR=$(SRCS)
-LEAN_COUNT=$$(find "$$OUT_DIR" -name '*.lean' | wc -l | tr -d ' ')
-echo "aeneas_translate produced $$LEAN_COUNT .lean file(s) under $$OUT_DIR"
-if [ "$$LEAN_COUNT" -lt 1 ]; then
-    echo "ERROR: aeneas_translate produced no .lean files" >&2
+LEAN=$(SRCS)
+if [ ! -s "$$LEAN" ]; then
+    echo "ERROR: aeneas_translate produced an empty .lean module at $$LEAN" >&2
     exit 1
 fi
-echo "OK $$LEAN_COUNT" > $@
+echo "aeneas_translate produced $$LEAN ($$(wc -c < "$$LEAN") bytes)"
+echo "OK" > $@
 """,
     testonly = True,
+)
+
+# Level 2: COMPILE the translated Lean against the Aeneas support library.
+# This kernel-checks that the translation elaborates — the bridge from
+# "translates Rust" to "compiles the Rust model in Lean" (closes the
+# translate->compile gap modelled on rules_rocq_rust's rocq_library).
+lean_library(
+    name = "hello_compiled",
+    srcs = [":hello_lean"],
+    deps = ["@aeneas_lean_lib//:Aeneas"],
 )

--- a/tests/charon_llbc/BUILD.bazel
+++ b/tests/charon_llbc/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_lean//aeneas:defs.bzl", "aeneas_translate", "charon_llbc")
-load("@rules_lean//lean:defs.bzl", "lean_library")
+load("@rules_lean//lean:defs.bzl", "lean_library", "lean_proof_test")
 
 # Translate the tiny Rust crate to LLBC via Charon.
 charon_llbc(
@@ -62,4 +62,16 @@ lean_library(
     name = "hello_compiled",
     srcs = [":hello_lean"],
     deps = ["@aeneas_lean_lib//:Aeneas"],
+)
+
+# Verify: prove properties about the translated Rust functions and kernel-check
+# them (zero sorry/axiom). The verification payoff — Rust correctness proved in
+# Lean, modelled on rules_rocq_rust's point_proofs.v.
+lean_proof_test(
+    name = "hello_verified",
+    srcs = ["HelloProofs.lean"],
+    deps = [
+        ":hello_compiled",
+        "@aeneas_lean_lib//:Aeneas",
+    ],
 )

--- a/tests/charon_llbc/HelloProofs.lean
+++ b/tests/charon_llbc/HelloProofs.lean
@@ -26,6 +26,6 @@ theorem add.spec (x y : U32) (h : x.val + y.val ≤ U32.max) :
 /-- `identity` returns its input unchanged. -/
 theorem identity.spec (x : U64) :
     identity x ⦃ y => y = x ⦄ := by
-  unfold identity
+  simp [identity]
 
 end hello

--- a/tests/charon_llbc/HelloProofs.lean
+++ b/tests/charon_llbc/HelloProofs.lean
@@ -27,6 +27,5 @@ theorem add.spec (x y : U32) (h : x.val + y.val ≤ U32.max) :
 theorem identity.spec (x : U64) :
     identity x ⦃ y => y = x ⦄ := by
   unfold identity
-  step
 
 end hello

--- a/tests/charon_llbc/HelloProofs.lean
+++ b/tests/charon_llbc/HelloProofs.lean
@@ -1,0 +1,32 @@
+/-
+Formal verification of the translated Rust crate (src/lib.rs).
+
+  Rust  →  Charon (LLBC)  →  Aeneas (Lean)  →  these proofs
+
+`hello_lean` is the Aeneas translation of `add`/`identity`; here we state and
+kernel-check properties about that translation, using Aeneas's `⦃ ⦄`
+progress-spec notation. This is the verification payoff: a property of the Rust
+code, proved in Lean, checked in CI with zero `sorry`/axiom.
+-/
+import Aeneas
+import hello_lean
+open Aeneas Std Result
+
+#setup_aeneas_simps
+
+namespace hello
+
+/-- `add` returns exactly the sum when it doesn't overflow. -/
+theorem add.spec (x y : U32) (h : x.val + y.val ≤ U32.max) :
+    add x y ⦃ z => z.val = x.val + y.val ⦄ := by
+  unfold add
+  step as ⟨ z ⟩
+  scalar_tac
+
+/-- `identity` returns its input unchanged. -/
+theorem identity.spec (x : U64) :
+    identity x ⦃ y => y = x ⦄ := by
+  unfold identity
+  step
+
+end hello

--- a/tests/charon_llbc/MODULE.bazel
+++ b/tests/charon_llbc/MODULE.bazel
@@ -42,7 +42,19 @@ use_repo(
     "aeneas_lean_lib",
 )
 
+# Lean toolchain to COMPILE the aeneas-translated Lean + write proofs against it.
+# Must match @aeneas_lean_lib's lean_version (4.28.0-rc1) so the oleans are
+# compatible. Dev-mode (require_hashes=False) since rules_lean stably pins only
+# 4.27.0/4.29.1 — this RC is downloaded directly.
+lean = use_extension("@rules_lean//lean:extensions.bzl", "lean")
+lean.toolchain(
+    version = "4.28.0-rc1",
+    require_hashes = False,
+)
+use_repo(lean, "lean_toolchains")
+
 register_toolchains(
     "@charon_toolchains//:all",
     "@aeneas_toolchains//:all",
+    "@lean_toolchains//:all",
 )


### PR DESCRIPTION
Completes the Rust verification pipeline, modelled on `rules_rocq_rust/examples/rust_to_rocq`. **All CI green**, including the heavy `Aeneas Lean lib build` job which now runs the full chain.

## The full chain — now CI-proven
**Rust → Charon (LLBC) → Aeneas (Lean) → compile → PROVE**
- `charon_llbc` (Rust→LLBC) and `aeneas_translate` (LLBC→Lean, now a discrete `.lean` module).
- `hello_compiled`: `lean_library` compiling the translated model against `@aeneas_lean_lib`.
- `hello_verified`: `lean_proof_test` kernel-checking properties of the translated functions (zero `sorry`/axiom):
  - `add.spec` — no-overflow add returns the exact sum;
  - `identity.spec` — identity returns its input.

## Fixes this surfaced (each only exposable by an actual compile/proof)
- `_required_lean_from_rev` stripped `-rcN`, falsely flagging RC Lean (4.28.0-rc1) vs RC Mathlib skew.
- `aeneas_translate` now emits a discrete `.lean` (removes the TreeArtifact blocker).
- aeneas olean consolidation: prefer `.lake/build/lib/lean` (flat layout) **and** copy Mathlib from `mathlib4_src` (the #7 local-path redirect moved it out of `.lake/packages`).
- aeneas binary is at the tarball root, not `bin/`.
- CI Linux jobs migrated to the org self-hosted runner pool (`light`/`rust-cpu`); GitHub-hosted `ubuntu-latest` no longer allocated.

## Shared infra
`lean/private/mathlib_fetch.bzl` — the #7 shallow-fetch helper used by both `mathlib_repo` and `aeneas_lean_lib`.

Advances #1 (FEAT-006). Dev-mode pin (no sha256 yet) — pin hashes follow-up. The `aeneas_verified_library` convenience macro (translate+compile+prove in one) is a remaining nicety; the example demonstrates the full pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)