### PR TITLE
chore(aeneas): pin sha256 hashes (drop dev-mode for the Level-2 example)

### DIFF
--- a/lean/extensions.bzl
+++ b/lean/extensions.bzl
@@ -19,6 +19,15 @@ _KNOWN_VERSIONS = {
             "linux_aarch64": "1ccdfb7f924901f4b73a4b4eb169e5b3dc74f6836521b47e733ea25f2abfc0dc",
         },
     },
+    # RC pinned for the Aeneas pipeline (aeneas's backends/lean tracks it).
+    "4.28.0-rc1": {
+        "sha256": {
+            "darwin_aarch64": "0113153c14ac6952c2b672cc22dc8a18cbc503a3a59a7f4f88250aa6ae7fac29",
+            "darwin_x86_64": "759b5df12fcec42765aad1eb89782e0bb05baaf6ac6cfae125d667e4f1ab97e9",
+            "linux_x86_64": "a3b013a20233f51852ebeb5e54967298a37aff055546170a40f1e79234bb9f4d",
+            "linux_aarch64": "edada5b461cdc85f3ed3a5f0a6191c48c7ad0c0199d36960618e55bab44c7a49",
+        },
+    },
 }
 
 def _detect_host_platform(module_ctx):

--- a/tests/charon_llbc/MODULE.bazel
+++ b/tests/charon_llbc/MODULE.bazel
@@ -15,17 +15,21 @@ aeneas.charon_toolchain(
     version = "build-2026.04.22.081730-2d35584fb79ef804c50f106d8c40bd3728284f8d",
 )
 
-# Aeneas binary toolchain (LLBC -> Lean). DEV-MODE pin (no sha256 yet):
+# Aeneas binary toolchain (LLBC -> Lean), hermetically pinned:
 #   - version/rev: aeneas build-2026.04.22 — same day as the charon pin above,
 #     so the LLBC formats line up.
 #   - lean_version 4.28.0-rc1 is what this aeneas's backends/lean/lean-toolchain
-#     requires (Aeneas tracks bleeding-edge Lean; rules_lean only stably pins
-#     4.27.0/4.29.1, so the Lean lib build uses this RC directly).
-# Pin sha256 hashes once the end-to-end build is confirmed green.
+#     requires (Aeneas tracks bleeding-edge Lean; now in _KNOWN_VERSIONS).
+#   - sha256: per-platform hashes of the aeneas-<platform>.tar.gz binaries.
 aeneas.toolchain(
     version = "build-2026.04.22.084123-1a8946778f0934266d63564c2aac74ec1fff4b68",
     rev = "1a8946778f0934266d63564c2aac74ec1fff4b68",
     lean_version = "4.28.0-rc1",
+    sha256 = {
+        "macos_aarch64": "62393cd005c67290fc38cf0e4361f9bf242b73e695aa1777bd7685023a60db09",
+        "macos_x86_64": "6320148064af0c98c556f27c66077309869e585da449776c53dde65d21da6ae2",
+        "linux_x86_64": "f0b9e245c11eae567ab57317e91fca3fc090a246d2ebdb8d618d8d70b90c8ecc",
+    },
 )
 
 use_repo(
@@ -44,13 +48,10 @@ use_repo(
 
 # Lean toolchain to COMPILE the aeneas-translated Lean + write proofs against it.
 # Must match @aeneas_lean_lib's lean_version (4.28.0-rc1) so the oleans are
-# compatible. Dev-mode (require_hashes=False) since rules_lean stably pins only
-# 4.27.0/4.29.1 — this RC is downloaded directly.
+# compatible. 4.28.0-rc1 is now in _KNOWN_VERSIONS with hashes, so this is fully
+# hash-verified (require_hashes defaults True).
 lean = use_extension("@rules_lean//lean:extensions.bzl", "lean")
-lean.toolchain(
-    version = "4.28.0-rc1",
-    require_hashes = False,
-)
+lean.toolchain(version = "4.28.0-rc1")
 use_repo(lean, "lean_toolchains")
 
 register_toolchains(


### PR DESCRIPTION
Hardens the merged Aeneas verification example: hash-verifies the Lean 4.28.0-rc1 toolchain (added to `_KNOWN_VERSIONS`, `require_hashes` back to default) and the aeneas binary (per-platform `sha256`). Hashes computed by streaming the pinned release tarballs through `shasum -a 256`.

Validation: `bazel query //:hello_compiled` resolves with hashes required; CI re-downloads + verifies on the heavy job (MODULE edit changed the cache key).

Follow-up: aeneas_lean_lib's internal Lean download + the aeneas source tarball (needs a source-sha256 attr). mathlib is git-tag-pinned; charon already hash-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)