### PR TITLE
fix(mathlib): always lake build after cache get (robust to incomplete upstream cache)

### DIFF
--- a/lean/private/repo.bzl
+++ b/lean/private/repo.bzl
@@ -180,25 +180,36 @@ def _mathlib_repo_impl(rctx):
     if result.return_code != 0:
         fail("lake update failed:\n" + result.stderr)
 
-    # Download pre-built oleans (fast path)
+    # Download pre-built oleans (fast path). Retry a few times to ride out
+    # transient upstream cache misses: `lake exe cache get` can return 0 yet
+    # leave gaps when Mathlib's Azure cache is momentarily incomplete ("some
+    # files were not found in the cache").
+    for attempt in range(3):
+        result = rctx.execute(
+            [str(lake), "exe", "cache", "get"],
+            environment = env,
+            timeout = 1200,
+            quiet = False,
+        )
+        if result.return_code == 0:
+            break
+        # buildifier: disable=print
+        print("WARNING: `lake exe cache get` attempt {} failed; retrying.".format(attempt + 1))
+
+    # ALWAYS follow with `lake build Mathlib` — the canonical Mathlib workflow.
+    # It is a fast no-op when the cache supplied every olean, and fills any the
+    # cache was missing. Building only on a non-zero `cache get` (as before) let
+    # a 0-exit-but-incomplete cache through, leaving lib/Mathlib empty and
+    # tripping the consolidation check downstream (an intermittent nightly
+    # failure when upstream Mathlib cache was incomplete).
     result = rctx.execute(
-        [str(lake), "exe", "cache", "get"],
+        [str(lake), "build", "Mathlib"],
         environment = env,
-        timeout = 1200,
+        timeout = 7200,
         quiet = False,
     )
     if result.return_code != 0:
-        # Pre-built cache may be unavailable — fall back to building from source
-        # buildifier: disable=print
-        print("WARNING: pre-built Mathlib cache unavailable, building from source (this will take a long time)...")
-        result = rctx.execute(
-            [str(lake), "build", "Mathlib"],
-            environment = env,
-            timeout = 7200,
-            quiet = False,
-        )
-        if result.return_code != 0:
-            fail("Failed to build Mathlib:\n" + result.stderr)
+        fail("Failed to build Mathlib (after cache get):\n" + result.stderr)
 
     # Consolidate all package oleans into lib/
     # Lake v4 stores oleans at: .lake/packages/<name>/.lake/build/lib/lean/<Module>/...


### PR DESCRIPTION
## The issue
The nightly cold-cache CI failed intermittently (06-11, 06-12 — self-healed 06-13). Root cause: `lake exe cache get` returns exit 0 even when Mathlib's upstream Azure cache is momentarily incomplete ('some files were not found in the cache'), so `lib/Mathlib` came out empty and the CC-006 consolidation check **correctly** refused to ship a broken `@mathlib` (`oleans: source=10 consolidated=9`). The source-build fallback only fired on a *non-zero* cache get, so a 0-exit-but-empty cache slipped past it.

## Fix
Retry `cache get` (transient misses), then **always** `lake build Mathlib` — the canonical `cache get` + `build` workflow. It's a fast no-op when the cache supplied everything and fills any gaps otherwise. `aeneas_lean_lib` already always-builds, so it was unaffected.

CI `build-mathlib` exercises the new path (cache complete → `lake build` no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)